### PR TITLE
add check contexts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "github_branch_protection" "main" {
 
   required_status_checks {
     strict  = true
-    context = "${var.status_checks_context}"
+    context = "${var.status_checks_contexts}"
   }
 
   required_pull_request_reviews {

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,8 @@ resource "github_branch_protection" "main" {
   enforce_admins = true
 
   required_status_checks {
-    strict = true
+    strict  = true
+    context = "${var.status_checks_contexts}"
   }
 
   required_pull_request_reviews {

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "github_branch_protection" "main" {
 
   required_status_checks {
     strict  = true
-    context = "${var.status_checks_contexts}"
+    context = "${var.status_checks_context}"
   }
 
   required_pull_request_reviews {

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,8 @@ resource "github_branch_protection" "main" {
   enforce_admins = true
 
   required_status_checks {
-    strict  = true
-    context = "${var.status_checks_contexts}"
+    strict   = true
+    contexts = "${var.status_checks_contexts}"
   }
 
   required_pull_request_reviews {

--- a/variables.tf
+++ b/variables.tf
@@ -113,5 +113,5 @@ variable "dismiss_review_users" {
 variable "status_check_contexts" {
   type        = "list"
   default     = []
-  description = "The list of required status checks in order to merge into the protected branch"
+  description = "The list of required status checks in order to merge into the protected branch, e.g. AWS CodeBuild ap-southeast-1 (<codebuild_project_name>)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -107,11 +107,11 @@ variable "admin_collaborators" {
 variable "dismiss_review_users" {
   type        = "list"
   default     = []
-  description = "the users which is granted the access to dismiss review on the repository"
+  description = "the users which is granted the access to dismiss review on the protected branch"
 }
 
 variable "status_check_contexts" {
   type        = "list"
   default     = []
-  description = "the users which is granted the access to dismiss review on the repository"
+  description = "The list of required status checks in order to merge into the protected branch"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,9 @@ variable "dismiss_review_users" {
   default     = []
   description = "the users which is granted the access to dismiss review on the repository"
 }
+
+variable "status_check_contexts" {
+  type        = "list"
+  default     = []
+  description = "the users which is granted the access to dismiss review on the repository"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ variable "dismiss_review_users" {
   description = "the users which is granted the access to dismiss review on the protected branch"
 }
 
-variable "status_checks_context" {
+variable "status_checks_contexts" {
   type        = "list"
   default     = []
   description = "The list of required status checks in order to merge into the protected branch, e.g. AWS CodeBuild ap-southeast-1 (<codebuild_project_name>)"

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ variable "dismiss_review_users" {
   description = "the users which is granted the access to dismiss review on the protected branch"
 }
 
-variable "status_check_contexts" {
+variable "status_checks_context" {
   type        = "list"
   default     = []
   description = "The list of required status checks in order to merge into the protected branch, e.g. AWS CodeBuild ap-southeast-1 (<codebuild_project_name>)"


### PR DESCRIPTION
to make checks (e.g. successfull AWS codebuild build)  required in code reviews, We need to specify those checks to the check context added by this PR. For codebuild the format is:
`AWS CodeBuild <region> (<codebuild_project_name>)`