### PR TITLE
unforce rebase

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "github_branch_protection" "main" {
   enforce_admins = true
 
   required_status_checks {
-    strict   = true
+    strict   = "${var.force_pr_rebase}"
     contexts = "${var.status_checks_contexts}"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,12 @@ variable "dismiss_review_users" {
   description = "the users which is granted the access to dismiss review on the protected branch"
 }
 
+variable "force_pr_rebase" {
+  type        = "string"
+  default     = false
+  description = "whether PR should have up to date branches (e.g. rebased) before they're merged"
+}
+
 variable "status_checks_contexts" {
   type        = "list"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,7 @@ variable "dismiss_review_users" {
 
 variable "force_pr_rebase" {
   type        = "string"
-  default     = false
+  default     = true
   description = "whether PR should have up to date branches (e.g. rebased) before they're merged"
 }
 


### PR DESCRIPTION
make "force up to date pull requests" optional, so users may merge PRs even if it's not up to date. This is useful for repositories where updates are frequent (e.g. large/open source repositories)