### PR TITLE
Fix error leading to module failure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "github_branch_protection" "main" {
 
   required_pull_request_reviews {
     dismiss_stale_reviews      = true
-    dismissal_users            = var.dismiss_review_users
+    dismissal_users            = "${var.dismiss_review_users}"
     require_code_owner_reviews = true
   }
 }


### PR DESCRIPTION
Terraform init fails with error (due to syntax):
```
Error downloading modules: Error loading modules: module this: Error parsing .terraform/modules/a47393dab170a572bc32e7f675513575/main.tf: At 37:34: Unknown token: 37:34 IDENT var.dismiss_review_users
```