### PR TITLE
Change admin enforcement as variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "github_repository" "main" {
 resource "github_branch_protection" "main" {
   repository     = "${github_repository.main.name}"
   branch         = "${github_repository.main.default_branch}"
-  enforce_admins = true
+  enforce_admins = "${var.enforce_admins}"
 
   required_status_checks {
     strict   = "${var.force_pr_rebase}"

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "archived" {
   description = "whether the repository should be archived or not"
 }
 
+variable "enforce_admins" {
+  type        = "string"
+  default     = true
+  description = "whether the admin should be enforced for branch protection or not"
+}
+
 variable "status_checks_contexts" {
   type        = "list"
   default     = []


### PR DESCRIPTION
In relation to sonarcloud integration, we want admin to be able to still merge & squash PR that doesn't fill the minimum test coverage percentage. Usually needed for multirepo migration related PR