### PR TITLE
Update example and collaborator permission setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # terraform-github-repository
-A Terraform module which creates a github repository
+A Terraform module which creates a github repository. terraform v0.12.x is required.
 
 ## Usage
 ```hcl
@@ -7,14 +7,39 @@ module "my-repository" {
     source = "github.com/traveloka/terraform-github-repository?ref=master"
     name = "flight-api"
     description = "flight team repository that contains flight backend API module"
+
+    // setting permission
+    repository_teams_permission = {
+      <team_1> = "admin"
+      <team_2> = "triage"
+      <team_3> = "maintain"
+      <team_4> = "push"
+      <team_5> = "pull"
+    }
+
+    repository_collaborators_permission = {
+      <username_1> = "admin"
+      <username_2> = "push"
+      <username_3> = "pull"
+    }
+
+    // see other available parameters in the variables.tf file
 }
 
 ```
 
-## Conventions
+## Caveat
+### terraform for_each and count
+The `repository_collaborators_permission` utilizes terraform 0.12's `for_each` meta-argument, so list reordering (e.g. reversing item order inside the list) is fine.
+
+However, it's not the case with `repository_teams_permission` as it's not as straightforward as collaborators (terraform needs team id, not team name). Therefore, reorganizing the items in this list will force resource recreation (old permission will be deleted, which potentially disable your access to the repository)
+
+### new permissions
+`triage` and `maintain` permission doesn't seem to work with `repository_collaborators_permission`. Read https://github.com/terraform-providers/terraform-provider-github/pull/303#issuecomment-602178599
 
 ## Authors
   - [Salvian Reynaldi](https://github.com/salvianreynaldi)
+
 
 ## License
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,28 +1,20 @@
+provider "github" {
+  version = "2.4.1"
+  organization = "salvianreynalditest"
+}
+
 module "this" {
   source                      = "../.."
   name                        = "my-experiment-repository"
-  description                 = "my experiment repository"
+  description                 = "my-experiment-repository"
   private                     = false
 
   repository_teams_permission = {
-    "team_1" = "pull"
-    "team_1" = "push"
-    "team_1" = "admin"
-
-    # only the last setting below ("push") will be applied for "team_1"
-    "team_1" = "push"
-    "team_2" = "push"
-    "team_3" = "pull"
+    "team1"="maintain"
+    "team2"="triage"
   }
 
   repository_collaborators_permission = {
-    "user_1" = "admin"
-    "user_2" = "pull"
-    "user_3" = "admin"
-    "user_3" = "push"
-    "user_3" = "pull"
-
-    # only the last setting below ("admin") will be applied for "user_3"
-    "user_3" = "admin"
+    "salvianreynaldi" = "admin"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,35 +1,35 @@
 data "github_team" "team_ids" {
-  count = "${length(keys(var.repository_teams_permission))}"
-  slug  = "${element(keys(var.repository_teams_permission), count.index)}"
+  count = length(keys(var.repository_teams_permission))
+  slug  = element(keys(var.repository_teams_permission), count.index)
 }
 
 resource "github_repository" "main" {
-  name               = "${var.name}"
-  description        = "${var.description}"
-  homepage_url       = "${var.homepage_url}"
-  private            = "${var.private}"
-  has_issues         = "${var.has_issues}"
-  has_wiki           = "${var.has_wiki}"
-  allow_merge_commit = "${var.allow_merge_commit}"
-  allow_squash_merge = "${var.allow_squash_merge}"
-  allow_rebase_merge = "${var.allow_rebase_merge}"
-  has_downloads      = "${var.has_downloads}"
-  auto_init          = "${var.auto_init}"
-  gitignore_template = "${var.gitignore_template}"
-  license_template   = "${var.license_template}"
-  default_branch     = "${var.default_branch}"
-  archived           = "${var.archived}"
-  topics             = "${var.topics}"
+  name               = var.name
+  description        = var.description
+  homepage_url       = var.homepage_url
+  private            = var.private
+  has_issues         = var.has_issues
+  has_wiki           = var.has_wiki
+  allow_merge_commit = var.allow_merge_commit
+  allow_squash_merge = var.allow_squash_merge
+  allow_rebase_merge = var.allow_rebase_merge
+  has_downloads      = var.has_downloads
+  auto_init          = var.auto_init
+  gitignore_template = var.gitignore_template
+  license_template   = var.license_template
+  default_branch     = var.default_branch
+  archived           = var.archived
+  topics             = var.topics
 }
 
 resource "github_branch_protection" "main" {
-  repository     = "${github_repository.main.name}"
-  branch         = "${github_repository.main.default_branch}"
-  enforce_admins = "${var.enforce_admins}"
+  repository     = github_repository.main.name
+  branch         = github_repository.main.default_branch
+  enforce_admins = var.enforce_admins
 
   required_status_checks {
-    strict   = "${var.force_pr_rebase}"
-    contexts = "${var.status_checks_contexts}"
+    strict   = var.force_pr_rebase
+    contexts = var.status_checks_contexts
   }
 
   required_pull_request_reviews {
@@ -40,15 +40,16 @@ resource "github_branch_protection" "main" {
 }
 
 resource "github_team_repository" "this" {
-  count      = "${length(keys(var.repository_teams_permission))}"
-  team_id    = "${element(data.github_team.team_ids.*.id, count.index)}"
-  repository = "${github_repository.main.name}"
-  permission = "${element(values(var.repository_teams_permission), count.index)}"
+  count      = length(keys(var.repository_teams_permission))
+  team_id    = element(data.github_team.team_ids.*.id, count.index)
+  repository = github_repository.main.name
+  permission = element(values(var.repository_teams_permission), count.index)
 }
 
 resource "github_repository_collaborator" "this" {
-  count      = "${length(keys(var.repository_collaborators_permission))}"
-  username   = "${element(keys(var.repository_collaborators_permission), count.index)}"
-  repository = "${github_repository.main.name}"
-  permission = "${element(values(var.repository_collaborators_permission), count.index)}"
+  for_each = var.repository_collaborators_permission
+  username   = each.key
+  repository = github_repository.main.name
+  permission = each.value
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,10 @@
 output "full_name" {
-  value       = "${github_repository.main.full_name}"
+  value       = github_repository.main.full_name
   description = "A string of the form 'orgname/reponame'"
 }
 
 output "clone_url" {
-  value       = "${github_repository.main.ssh_clone_url}"
+  value       = github_repository.main.ssh_clone_url
   description = "URL that can be provided to git clone to clone the repository via SSH"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "the repository name"
 }
 
 variable "description" {
-  type        = "string"
+  type        = string
   description = "the repository description"
 }
 
@@ -69,47 +69,48 @@ variable "default_branch" {
 }
 
 variable "dismiss_review_users" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "the users which is granted the access to dismiss review on the protected branch"
 }
 
 variable "repository_teams_permission" {
-  type        = "map"
+  type        = map(string)
   description = "the team permission settings for the repository; each team is mapped to a permission (admin, pull, or push)"
 }
 
 variable "repository_collaborators_permission" {
-  type        = "map"
+  type        = map(string)
   description = "the collaborator permission settings for the repository; each username is mapped to a permission (admin, pull, or push)"
 }
 
 variable "force_pr_rebase" {
-  type        = "string"
+  type        = string
   default     = true
   description = "whether PR should have up to date branches (e.g. rebased) before they're merged"
 }
 
 variable "topics" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "the repository topics"
 }
 
 variable "archived" {
-  type        = "string"
+  type        = string
   default     = false
   description = "whether the repository should be archived or not"
 }
 
 variable "enforce_admins" {
-  type        = "string"
+  type        = string
   default     = true
   description = "whether the admin should be enforced for branch protection or not"
 }
 
 variable "status_checks_contexts" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "The list of required status checks in order to merge into the protected branch, e.g. AWS CodeBuild ap-southeast-1 (<codebuild_project_name>)"
 }
+


### PR DESCRIPTION
1. To prevent people access to the created repositories from getting revoked, we need to migrate how we set permission  from `count` to `for_each`. For_each will identify elements by the given fixed string, not the dynamic index.
2. I add terraform provider block to the example
3. Upgrade to terraform 0.12 syntax