### PR TITLE
Use for_each for team permission setting

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,17 +1,16 @@
 provider "github" {
-  version = "2.4.1"
   organization = "salvianreynalditest"
 }
 
 module "this" {
-  source                      = "../.."
-  name                        = "my-experiment-repository"
-  description                 = "my-experiment-repository"
-  private                     = false
+  source      = "../.."
+  name        = "my-experiment-repository"
+  description = "my-experiment-repository"
+  private     = false
 
   repository_teams_permission = {
-    "team1"="maintain"
-    "team2"="triage"
+    "team1" = "maintain"
+    "team2" = "triage"
   }
 
   repository_collaborators_permission = {

--- a/variables.tf
+++ b/variables.tf
@@ -133,11 +133,11 @@ variable "license_template" {
 variable "template_repository" {
   type        = string
   default     = ""
-  description = "The name of repository template for creating the new repository" 
+  description = "The name of repository template for creating the new repository"
 }
 
 variable "template_owner" {
   type        = string
   default     = ""
-  description = "The name of organization who owned the repository template" 
+  description = "The name of organization who owned the repository template"
 }


### PR DESCRIPTION
fixes #14. With for_each (terraform 0.12+), permission setting won't be recreated even if the order in the input variable changes
cc @andrewsaputra 